### PR TITLE
Add travis config, fix brew strict audit warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+os: osx
+addons:
+    homebrew:
+        taps: dnote/dnote
+        packages:
+            - dnote
+script:
+- brew audit dnote
+- dnote version

--- a/Formula/dnote.rb
+++ b/Formula/dnote.rb
@@ -1,5 +1,5 @@
 class Dnote < Formula
-  desc "Capture your learning without leaving the command line"
+  desc "Capture your learning without leaving the command-line"
   homepage "https://dnote.io"
   url "https://github.com/dnote/dnote/releases/download/cli-v0.8.2/dnote_0.8.2_darwin_amd64.tar.gz"
   version "0.8.2"
@@ -7,5 +7,9 @@ class Dnote < Formula
 
   def install
     bin.install "dnote"
+  end
+
+  test do
+    system bin/"dnote", "version"
   end
 end


### PR DESCRIPTION
Added a really basic Travis-CI config file so that we'll know if the latest release can be downloaded and installed. It only checks that it can tap and install the `dnote` package and produce a `dnote version`.

Also updated two small things that were called out in `brew audit --strict dnote`. I think maybe in the next release line 9 in `.travis.yml` could be updated to run `brew audit --strict dnote`. I couldn't include that change in this PR or else the build step would fail without these changes - a catch-22 😝 !

Edit: Here's an example of the passing tests: https://travis-ci.org/jamesa/homebrew-dnote/builds/544847225