### PR TITLE
Update dnote.rb

### DIFF
--- a/Formula/dnote.rb
+++ b/Formula/dnote.rb
@@ -1,7 +1,7 @@
 class Dnote < Formula
   desc "Simple command-line notebook for programmers"
   homepage "https://www.getdnote.com"
-  url "https://github.com/dnote/dnote/releases/download/cli-v0.13.0/dnote_0.14.0_darwin_amd64.tar.gz"
+  url "https://github.com/dnote/dnote/releases/download/cli-v0.14.0/dnote_0.14.0_darwin_amd64.tar.gz"
   version "0.14.0"
   sha256 "c34dfd5a7a47e5452a421fe0790d3aa9be5aa1307b95f7e2cff8ca21dee17576 "
 


### PR DESCRIPTION
Fix incorrect URL for version 0.14

```
~ % brew install dnote
==> Fetching dnote/dnote/dnote
==> Downloading https://github.com/dnote/dnote/releases/download/cli-v0.13.0/dno
curl: (22) The requested URL returned error: 404

Error: dnote: Failed to download resource "dnote"
Download failed: https://github.com/dnote/dnote/releases/download/cli-v0.13.0/dnote_0.14.0_darwin_amd64.tar.gz
```